### PR TITLE
Suggested changes to pull "name" instead of value for some custom fields and added logic to pull resolution date if (Resolved) in last workflow stage

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"strconv"  	
 )
 
 var sections = []string{"Connection", "Criteria", "Workflow", "Attributes"}
-var connectionKeys = []string{"Domain", "Username", "Password"}
+var connectionKeys = []string{"Domain", "Username", "Password", "BatchSize"}
 var criteriaKeys = []string{"Types", "Projects", "Filters"}
 var attributeFields = []string{"status", "issuetype", "priority", "resolution", "project",
 	"labels", "fixVersions", "components"}
@@ -29,6 +30,7 @@ type Config struct {
 	UrlRoot  string
 	Username string
 	Password string
+	BatchSize int 
 
 	// criteria stuff
 	ProjectNames []string
@@ -176,6 +178,13 @@ func LoadConfigFromLines(lines []string) (*Config, error) {
 	}
 	config.Password = properties["Password"]
 
+	batchSizeFromConfig, err := strconv.Atoi(properties["BatchSize"])    
+	if err != nil {    
+		config.BatchSize = batchSize    
+	} else {    
+		config.BatchSize = batchSizeFromConfig    
+	}  
+	
 	// collect project names
 	if s, ok := properties["Projects"]; ok {
 		config.ProjectNames = parseList(s)

--- a/config.go
+++ b/config.go
@@ -178,13 +178,13 @@ func LoadConfigFromLines(lines []string) (*Config, error) {
 	}
 	config.Password = properties["Password"]
 
-	batchSizeFromConfig, err := strconv.Atoi(properties["BatchSize"])    
-	if err != nil {    
-		config.BatchSize = batchSize    
-	} else {    
-		config.BatchSize = batchSizeFromConfig    
-	}  
-	
+    batchSizeFromConfig, err := strconv.Atoi(properties["BatchSize"])
+    if err != nil {
+		config.BatchSize = batchSize
+	} else {
+		config.BatchSize = batchSizeFromConfig
+	}
+
 	// collect project names
 	if s, ok := properties["Projects"]; ok {
 		config.ProjectNames = parseList(s)

--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"strconv"  	
+	"strconv"
 )
 
 var sections = []string{"Connection", "Criteria", "Workflow", "Attributes"}
@@ -30,7 +30,7 @@ type Config struct {
 	UrlRoot  string
 	Username string
 	Password string
-	BatchSize int 
+	BatchSize int
 
 	// criteria stuff
 	ProjectNames []string

--- a/items.go
+++ b/items.go
@@ -253,6 +253,7 @@ func getItems(query string, config *Config) (items []*Item, unusedStages map[str
 					itemValue = getValue(fields, a.FieldName, "name")
 				}
 				item.Attributes[i] = itemValue
+
 				// handle predefined fields (can be struct, array of strings, array of structs)
 			} else {
 				switch a.FieldName {

--- a/items.go
+++ b/items.go
@@ -179,6 +179,20 @@ func getItems(query string, config *Config) (items []*Item, unusedStages map[str
 			creationDate := fields["created"].(string)
 			events[0] = append(events[0], creationDate)
 		}
+		if config.ResolvedInLastStage {
+			if (fields["status"] != nil) {
+				statusStruct := fields["status"]
+				statusName := statusStruct.(map[string]interface{})
+				issueStatus := statusName["name"].(string)
+				if (issueStatus == "Closed"){
+					if (fields["resolutiondate"] != nil) {
+						resolutionDate := fields["resolutiondate"].(string)
+						doneStageIndex := config.StageMap[strings.ToUpper("CLOSED")]
+						events[doneStageIndex] = append(events[doneStageIndex], resolutionDate)
+					}
+				}
+			}
+		}
 		for _, history := range issue.Changelog.Histories {
 			for _, jItem := range history.Items {
 				if jItem.Field == "status" {
@@ -234,8 +248,11 @@ func getItems(query string, config *Config) (items []*Item, unusedStages map[str
 
 			// handle customfield
 			if strings.HasPrefix(a.FieldName, "customfield_") {
-				item.Attributes[i] = getValue(fields, a.FieldName, a.ContentName)
-
+				itemValue := getValue(fields, a.FieldName, a.ContentName)
+				if (itemValue == ""){
+					itemValue = getValue(fields, a.FieldName, "name")
+				}
+				item.Attributes[i] = itemValue
 				// handle predefined fields (can be struct, array of strings, array of structs)
 			} else {
 				switch a.FieldName {


### PR DESCRIPTION
I have changes in 2 files for 2 issues that I was trying to address.

First, not all custom fields are configured the same way. Here are JSON examples of the two versions of custom fields

Custom field 1 has the following JSON structure:
			"customfield_10011": {
				"self": "https://jira.company.com/rest/api/2/customFieldOption/10011",
				"value": "No",
				"id": "10011"
			}

Custom field 2 has the following JSON structure:
			"customfield_15713": {
				"self": "https://jira2.company.com/rest/api/2/version/63728",
				"id": "63728",
				"name": "XY 2492",
				"archived": false,
				"released": false,
				"releaseDate": "2015-12-10"
			}

The logic for custom fields only pulled the structure with "value" (Custom field 1) and not with "name" (Custom field 2)
So, I added logic to check if the “value” element is empty, then pull the “name” element.  

Second, I found out that if you put (Created) in the first Section of the workflow, it will pull in the Created date (essentially, the submitted date) of the JIRA.  Well, we had a limitation for this in that when we migrated issues from another system db to JIRA, it did not migrate status changes (transitions).  So, all we had for the majority of those issues was the created date and the resolved date.  I added some logic that if you add (Resolved) to the last Section of the workflow, it will pick up the resolution date if it exists for the JIRA issue being imported.  This is very specific to the “Closed” status and will pull in issues that don’t have a status change to closed.  Essentially, it just goes after the migrated issues to provide some history.
