### PR TITLE
Added support for automatically including Epic Status status history …

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -30,7 +30,7 @@ To run the JIRA extraction process, run ```node jira-to-analytics```
 
 ```-o``` specifies output file name (must end with .csv or .json, defaults to data.csv)
 
-```-l``` or ```--leacy``` will enable the old version of the YAML (from the GO version of the application). 
+```-l``` or ```--legacy``` will enable the old version of the YAML (from the GO version of the application). 
 
 
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actionableagileimporttool",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "",
   "main": "dist/main.js",
   "typings": "dist/main",
@@ -33,6 +33,7 @@
     "core-js": "^2.4.0",
     "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.6.1",
-    "yargs": "^4.7.1"
+    "yargs": "^4.7.1",
+    "progress": "^1.1.8"
   }
 }

--- a/typescript/src/lib/extractors/jira/api-adapter/components/attribute-parser.ts
+++ b/typescript/src/lib/extractors/jira/api-adapter/components/attribute-parser.ts
@@ -1,22 +1,7 @@
-// if strings.HasPrefix(value, "customfield_") {
-//   valueParts := strings.SplitN(value, ".", 2)
-//   fieldName := valueParts[0]
-//   contentName := "value"
-//   if len(valueParts) > 1 {
-//     contentName = valueParts[1]
-//   }
-//   attr := ConfigAttr{key, fieldName, contentName}
-//   config.Attributes = append(config.Attributes, attr)
-
-
-
-const getAttributes = (fields: any, attributesRequested: any) => {
-  const attributeAliases = Object.keys(attributesRequested); // human name alias
-  return attributeAliases.reduce((attributesMap, attributeAlias) => {
-    // needs to add the customfield_ stuff...
-    const attributeSystemName: string = attributesRequested[attributeAlias];
+const getAttributes = (fields: any, attributesRequested: string[]) => {
+  // const attributesSystemNames = Object.keys(attributesRequested).map(key => attributesRequested[key]); // human name alias
+  return attributesRequested.reduce((attributesMap, attributeSystemName) => {
     const attributeData: any = fields[attributeSystemName];
-
 
     let subAttribute: string = null;
     if (attributeSystemName.startsWith('customfield_') && attributeSystemName.split('.').length > 1) {

--- a/typescript/src/lib/extractors/jira/extractor.ts
+++ b/typescript/src/lib/extractors/jira/extractor.ts
@@ -4,18 +4,20 @@ import { IWorkItem } from '../../core/work-item';
 
 class JiraExtractor {
   private settings: IJiraSettings;
+  private statusHook: any;
   private workItems: Array<IWorkItem>;
 
-  constructor(settings: IJiraSettings) {
+  constructor(settings: IJiraSettings, statusHook: any = () => {}) {
     if (!settings) {
       throw new Error('No JIRA Settings found. Must provide settings');
     }
     this.settings = settings;
+    this.statusHook = statusHook;
   }
 
-  getWorkItems(settings = this.settings): Promise<any> {
+  getWorkItems(settings = this.settings, hook = this.statusHook): Promise<any> {
     return new Promise((accept, reject) => {
-      getAllWorkItemsFromJiraApi(settings)
+      getAllWorkItemsFromJiraApi(settings, hook)
       .then(items => {
         this.workItems = items;
         accept(items);

--- a/typescript/src/lib/extractors/jira/settings.ts
+++ b/typescript/src/lib/extractors/jira/settings.ts
@@ -62,17 +62,17 @@ class JiraSettings implements IJiraSettings {
           this.Criteria = { Projects, IssueTypes, ValidResolutions, Filters, JQL };
         }
 
-        if (this.Criteria.JQL) {
-          console.warn('Custom JQL not currently supported');
-        }
+        // if (this.Criteria.JQL) {
+        //   console.warn('Custom JQL not currently supported');
+        // }
 
-        if (this.Criteria.ValidResolutions) {
-          console.warn('Valid Resolutions not currently supported');
-        }
+        // if (this.Criteria.ValidResolutions) {
+        //   console.warn('Valid Resolutions not currently supported');
+        // }
 
         const workflow = settings.legacy 
-          ? getWorkflowArray(settings.Workflow, convertCsvStringToArray) 
-          : getWorkflowArray(settings.Workflow, convertToArray);
+          ? convertWorkflowToArray(settings.Workflow, convertCsvStringToArray) 
+          : convertWorkflowToArray(settings.Workflow, convertToArray);
         this.Workflow = workflow;
 
         this.Attributes = settings.Attributes;
@@ -109,7 +109,7 @@ class JiraSettings implements IJiraSettings {
   }
 }
 
-const getWorkflowArray = (workflowObject: any, extractFunction: any) => {
+const convertWorkflowToArray = (workflowObject: any, extractFunction: any) => {
   const res = {};
   Object.keys(workflowObject).forEach(key => {
     res[key] = extractFunction(workflowObject[key]);

--- a/typescript/src/test/unit/jira/repository.spec.ts
+++ b/typescript/src/test/unit/jira/repository.spec.ts
@@ -29,11 +29,7 @@ describe('jira repository', () => {
         c: ['c', 2],
       };
 
-      const requestedAttributes = {
-        'A Letter': 'a',
-        'A Number': 'b',
-        'An Array': 'c',
-      };
+      const requestedAttributes = ['a', 'b', 'c'];
 
       const actual = getAttributes(fields, requestedAttributes);
       const expected = {

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.3.0",
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",

--- a/typescript/typings.json
+++ b/typescript/typings.json
@@ -4,7 +4,8 @@
     "isomorphic-fetch": "registry:dt/isomorphic-fetch#0.0.0+20160524142046",
     "js-yaml": "registry:dt/js-yaml#3.5.2+20160316171810",
     "mocha": "registry:dt/mocha#2.2.5+20160619032855",
-    "node": "registry:dt/node#6.0.0+20160621231320"
+    "node": "registry:dt/node#6.0.0+20160621231320",
+    "progress": "registry:dt/progress#1.1.8+20160317120654"
   },
   "dependencies": {
     "chai": "registry:npm/chai#3.5.0+20160415060238",


### PR DESCRIPTION
…into the extraction process for date analysis. Also added a realtime progress bar to the CLI version of the app. Currently working on way to make 'Epic Status' (or any attribute history) be included into the data analysis/extraction process and make it configurable. It is currently set to default to include Epic Status. To use, simply add the stages of your Epic Status to the workflow list. 

NOTE: If your Status and Epic Status have the same stages (for example: 'to do', 'in progress', and 'done') the extraction tool will combine the histories for them. Most Status and Epic Status move together. anyways. But a configurable solution is in development. 


Also added a sweet new progress bar for the command line version!