### PR TITLE
Updated query-builder.ts for start/end dates

### DIFF
--- a/src/components/query-builder.ts
+++ b/src/components/query-builder.ts
@@ -52,7 +52,7 @@ const buildJQL = (options: JQLOptions): string => {
   if (startDate && endDate) {
     const dateToExcludeStoriesBefore = startDate;
     const dateToExcludeStoriesAfter = endDate;
-    const dateFilterQuery = `((resolutionDate >= "${formatDate(dateToExcludeStoriesBefore)}" OR resolution = Unresolved) AND (resolutionDate <= "${formatDate(dateToExcludeStoriesAfter)}"))`;
+    const dateFilterQuery = `((resolutionDate >= "${formatDate(dateToExcludeStoriesBefore)}" AND resolutionDate <= "${formatDate(dateToExcludeStoriesAfter)}") or (resolution = Unresolved ))`;
     clauses.push(dateFilterQuery);
   } else if (startDate) {
     const dateToExcludeStoriesBefore = startDate;

--- a/src/components/query-builder.ts
+++ b/src/components/query-builder.ts
@@ -52,7 +52,7 @@ const buildJQL = (options: JQLOptions): string => {
   if (startDate && endDate) {
     const dateToExcludeStoriesBefore = startDate;
     const dateToExcludeStoriesAfter = endDate;
-    const dateFilterQuery = `((resolutionDate >= "${formatDate(dateToExcludeStoriesBefore)}" OR resolution = Unresolved) OR (resolutionDate <= "${formatDate(dateToExcludeStoriesAfter)}"))`;
+    const dateFilterQuery = `((resolutionDate >= "${formatDate(dateToExcludeStoriesBefore)}" OR resolution = Unresolved) AND (resolutionDate <= "${formatDate(dateToExcludeStoriesAfter)}"))`;
     clauses.push(dateFilterQuery);
   } else if (startDate) {
     const dateToExcludeStoriesBefore = startDate;


### PR DESCRIPTION
When specifying start and end dates, one must bundle them together using an AND operator. To still retrieve "unresolved" items, you must move that portion of the query outside of the paren' and make it a separate clause. 