### PR TITLE
Do not ignore offset en batchsize

### DIFF
--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -134,8 +134,8 @@ class JiraExtractor {
       {
         apiRootUrl,
         jql,
-        startIndex: 0,
-        batchSize: 1,
+        startIndex: startIndex,
+        batchSize: batchSize,
       });
     return queryUrl;
   }


### PR DESCRIPTION
Offset en batchSize were ignored when fetching issues. This resulted in the first item being pulled over and over again. This fixes issue #45 .