### PR TITLE
Add team configuration to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,23 @@ These fields will show up as filter attributes in the generated data file (pleas
 
 >NOTE::  None of the fields in this section is required--in fact, this section as a whole is optional.
 
+### Teams ###
+
+The teams section of the config file allows you to assign projects keys to team names, which can then be filtered on in the application.
+
+An example of what this section might look like is:
+
+```
+Teams:
+    TeamOne:
+      - ABC
+      - EFG
+    TeamTwo:
+      - HA
+      - HE
+      - HO
+```
+
 ### Advanced Settings ###
 
 The extraction tool also supports more customization and extensibility. 

--- a/src/components/yaml-converter.ts
+++ b/src/components/yaml-converter.ts
@@ -58,6 +58,8 @@ const convertYamlToJiraSettings = (config: any): JiraExtractorConfig => {
     : convertWorkflowToArray(config.Workflow, convertToArray);
   c.attributes = config.Attributes;
 
+  c.teams = config.Teams;
+
   c.featureFlags = config['Feature Flags'];
 
   return c;

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,10 @@ export interface FeatureFlags {
   [val: string]: boolean;
 };
 
+export interface Teams {
+  [val: string]: Array<string>;
+}
+
 export interface Auth {
   username?: string;
   password?: string;
@@ -89,4 +93,5 @@ export interface JiraExtractorConfig {
   attributes?: Attributes;
   featureFlags?: FeatureFlags;
   batchSize?: number;
+  teams?: Teams;
 };


### PR DESCRIPTION
At the company I work for there are several teams active. We are not using Jira portfolio or whatever you need to configure teams in Jira. These commits add a new option to the configuration file that allows you to group projects in to teams. This way you can have both the complete information and team info in one file.