### PR TITLE
Add logging of run parameters

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -107,7 +107,10 @@ const run = async function (cliArgs: any): Promise<void> {
   console.log(chalk.green('Authentication successful.\n'));
 
   console.log('Beginning extraction process');
-  console.log(`\tConfig file : ${jiraConfigPath}\n\tLegacy YAML : ${isLegacyYaml}\n\tDebug mode  : ${debugMode}\n\tOutput path : ${outputPath}\n\tOutput type : ${outputType}\n\tUsername    : ${cliUsername}\n\tPassword    : ********\n`);
+
+  if (debugMode) {
+    console.log(`\tConfig file : ${jiraConfigPath}\n\tLegacy YAML : ${isLegacyYaml}\n\tDebug mode  : ${debugMode}\n\tOutput path : ${outputPath}\n\tOutput type : ${outputType}\n\tUsername    : ${cliUsername}\n\tPassword    : ********\n`);
+  }
 
   // Progress bar setup
   const updateProgressHook = (bar => {

--- a/cli.ts
+++ b/cli.ts
@@ -107,6 +107,8 @@ const run = async function (cliArgs: any): Promise<void> {
   console.log(chalk.green('Authentication successful.\n'));
 
   console.log('Beginning extraction process');
+  console.log(`\tConfig file : ${jiraConfigPath}\n\tLegacy YAML : ${isLegacyYaml}\n\tDebug mode  : ${debugMode}\n\tOutput path : ${outputPath}\n\tOutput type : ${outputType}\n\tUsername    : ${cliUsername}\n\tPassword    : ********\n`);
+
   // Progress bar setup
   const updateProgressHook = (bar => {
     bar.tick();


### PR DESCRIPTION
I've been doing a lot of runs lately and I saw the need of know what the run parameters were for the current execution. 

So I added some logging of those (except the password, I thought was a good idea?)

And then I hid the whole thing under the `-d`-flag