### PR TITLE
Case insensitive status names

### DIFF
--- a/src/components/staging-parser.ts
+++ b/src/components/staging-parser.ts
@@ -35,12 +35,16 @@ const populateStages = (issue: JiraApiIssue, stageMap, stageBins, unusedStages =
   // sort status changes into stage bins
   issue.changelog.histories.forEach(history => {
     history.items.forEach(historyItem => {
+      const stageName: string = historyItem.toString;
+      const stageDate: string = history['created'];
+
       if (historyItem['field'] === 'status') {
-        const stageName: string = historyItem.toString;
         if (stageMap.has(stageName)) {
           const stageIndex: number = stageMap.get(stageName);
-          const stageDate: string = history['created'];
           stageBins[stageIndex].push(stageDate);
+        } else if (caseInsensetiveHas(stageMap, stageName)) {
+            const stageIndex: number = caseInsensetiveGet(stageMap, stageName);
+            stageBins[stageIndex].push(stageDate);
         } else {
           const count: number = unusedStages.has(stageName) ? unusedStages.get(stageName) : 0;
           unusedStages.set(stageName, count + 1);
@@ -53,9 +57,11 @@ const populateStages = (issue: JiraApiIssue, stageMap, stageBins, unusedStages =
         const stageName: string = historyItem.toString;
         if (stageMap.has(stageName)) {
           const stageIndex: number = stageMap.get(stageName);
-          const stageDate: string = history['created'];
           stageBins[stageIndex].push(stageDate);
-        } else {
+        } else if (caseInsensetiveHas(stageMap, stageName)) {
+          const stageIndex: number = caseInsensetiveGet(stageMap, stageName);
+          stageBins[stageIndex].push(stageDate);
+      } else {
           const count: number = unusedStages.has(stageName) ? unusedStages.get(stageName) : 0;
           unusedStages.set(stageName, count + 1);
         }

--- a/src/components/staging-parser.ts
+++ b/src/components/staging-parser.ts
@@ -19,6 +19,18 @@ const addResolutionDateToClosedStage = (issue: JiraApiIssue, stageMap, stageBins
   return stageBins;
 };
 
+const caseInsensetiveGet = (map: Map<string, any>, keyToGet: string) => {
+  const lowerCaseKeyToGet = keyToGet.toLowerCase()
+  const entries = [...map.entries()]
+  const found = entries.find(entry => entry[0].toLowerCase() === lowerCaseKeyToGet)
+  return found !== undefined ? found[1] : undefined
+}
+
+const caseInsensetiveHas = (map: Map<string, any>, keyToCheck: string) => {
+  return caseInsensetiveGet(map, keyToCheck) !== undefined
+}
+
+
 const populateStages = (issue: JiraApiIssue, stageMap, stageBins, unusedStages = new Map<string, number>()) => {
   // sort status changes into stage bins
   issue.changelog.histories.forEach(history => {
@@ -64,7 +76,7 @@ const filterAndFlattenStagingDates = (stageBins: string[][]) => {
       validStageDates.sort();
       latestValidIssueDateSoFar = validStageDates[validStageDates.length - 1];
       const earliestStageDate = validStageDates[0];
-      return earliestStageDate.split('T')[0]; 
+      return earliestStageDate.split('T')[0];
     } else {
       return '';
     }


### PR DESCRIPTION
This PR is a repeat of #52 that I messed up by deleting my repo. 

For full transparency, here's my previous description:
 
One problem I had was that I got the statuses, for the workflow mapping section of the config file, in all upper case. This ruined the map.get(key) and map.has(key) calls in populateStages.

I have added a new version that compares keys, case-insensitively, as an extra check in populateStages, after the original case-sensetive map-methods. Have not seen problems in my tests